### PR TITLE
Ta bort secure logs logback-config

### DIFF
--- a/api/src/main/resources/logback.xml
+++ b/api/src/main/resources/logback.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <include resource="no/nav/common/log/logback-default.xml"/>
+    <include resource="no/nav/common/log/logback-stdout-json.xml"/>
+    <include resource="no/nav/common/log/logback-naudit.xml"/>
+    <include resource="no/nav/common/log/logback-cxf.xml"/>
 </configuration>


### PR DESCRIPTION
secureLogs er ikke enabled, dermed mountes ikke mappe for securelogs, og logger blir forsøkt skrivet til en mappe uten tilgang.