### PR TITLE
Revert "Bruke ny ingress i dev"

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -10,7 +10,7 @@ spec:
   port: 8080
   webproxy: true
   ingresses:
-    - https://pto-admin.intern.dev.nav.no
+    - https://pto-admin.dev.intern.nav.no
   prometheus:
     enabled: true
     path: /internal/prometheus


### PR DESCRIPTION
Frontenden til pto-admin hostes dev-fss, så da er ikke denne ingress-endringen gyldig/nødvendig (dette ga feil ved deploy). Reverter derfor endringen.