### PR TITLE
Bruk poao-gruppe ikke pto-gruppe

### DIFF
--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -38,7 +38,7 @@ spec:
       allowAllUsers: false
       claims:
         groups:
-          - id: 41126212-6cb5-4c67-9ce1-22f7a686b298
+          - id: 6844decc-33c2-421f-b8e9-d1015f497174
   vault:
     enabled: true
     paths:


### PR DESCRIPTION
AD gruppen 41126212-6cb5-4c67-9ce1-22f7a68
![Skjermbilde 2023-08-07 kl  13 15 27](https://github.com/navikt/pto-admin/assets/7754140/3f1d5c5a-0552-4e98-9f54-91b4c3bff8ec)
6b298 (pto) har blitt slettet