### PR TITLE
Bytt til "nais/docker-build-push"-action

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -12,6 +12,10 @@ jobs:
   test-build-and-push:
     name: Test, build and push
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -39,18 +43,15 @@ jobs:
 
       - name: Build maven artifacts
         run: mvn -f ./api/pom.xml -B package
-      - name: Login to Docker
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
         with:
-          context: .
-          push: true
-          tags: ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+          team: pto
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+
   deploy-dev:
     name: Deploy application to dev
     needs: test-build-and-push
@@ -58,10 +59,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Deploy application
         uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-fss
           RESOURCE: nais-dev.yaml
-          VAR: version=${{ env.IMAGE_TAG }}
+          VAR: image=${{ needs.test-build-and-push.outputs.image }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,6 @@ name: Test, build, push and deploy
 on: push
 env:
   IMAGE_TAG: ${{ github.sha }}
-  IMAGE: ghcr.io/${{ github.repository }}/pto-admin
   PRINT_PAYLOAD: true
 permissions:
   packages: write
@@ -30,6 +29,10 @@ jobs:
     name: Test, build and push
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -57,18 +60,14 @@ jobs:
 
       - name: Build maven artifacts
         run: mvn -f ./api/pom.xml -B package
-      - name: Login to Docker
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
         with:
-          context: .
-          push: true
-          tags: ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+          team: pto
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
 
   deploy-dev:
     name: Deploy application to dev
@@ -78,13 +77,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Deploy application
         uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-fss
           RESOURCE: nais-dev.yaml
-          VAR: version=${{ env.IMAGE_TAG }}
+          VAR: image=${{ needs.test-build-and-push.outputs.image }}
+
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
@@ -96,18 +97,20 @@ jobs:
   deploy-prod:
     name: Deploy application to prod
     if: github.ref == 'refs/heads/main'
-    needs: deploy-dev
+    needs: [test-build-and-push, deploy-dev]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Deploy application
         uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-fss
           RESOURCE: nais-prod.yaml
-          VAR: version=${{ env.IMAGE_TAG }}
+          VAR: image=${{ needs.test-build-and-push.outputs.image }}
+
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:

--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: pto
 spec:
-  image: ghcr.io/navikt/pto-admin/pto-admin:{{version}}
+  image: {{image}}
   port: 8080
   webproxy: true
   ingresses:

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: pto
 spec:
-  image: ghcr.io/navikt/pto-admin/pto-admin:{{version}}
+  image: {{image}}
   port: 8080
   webproxy: true
   ingresses:


### PR DESCRIPTION
Bytter fra `docker/build-push-action` GitHub action til å bruke NAIS sin `nais/docker-build-push` GitHub action. Dette gir oss en del fordeler blant annet mtp. stabilitet ved image-pulls da `nais/docker-build-push` går mot Google Artifact Registry (GAR) i stedet for GitHub Container Registry (GHCR), samt automatisk signering/scanning av Docker images via SALSA.

Det står en god del om dette i NAIS-docen, bla.a. [Salsa - NAIS](https://doc.nais.io/security/salsa/salsa) og [OCI registry migration - NAIS](https://doc.nais.io/guides/oci-migration/). Noen relevante utdrag:

> [SLSA](https://slsa.dev/) is short for Supply chain Levels for Software Artifacts pronounced salsa.
>
> It is a security framework, essentially a checklist comprising standards and controls aimed at preventing tampering, enhancing integrity, and securing both packages and infrastructure within our projects.

> If you utilize the [nais/docker-build-push](https://github.com/nais/docker-build-push) action for building and pushing your container image, you will automatically receive a signed attestation/SBOM (Software Bill of Materials) for your container image and its dependencies. 
>
> This SBOM will be uploaded to your container registry along with your image. The attestation is generated by the [Trivy](https://github.com/aquasecurity/trivy-action) GitHub action and signed using [cosign](https://github.com/sigstore/cosign).

> Upon deploying your image to NAIS, the attestation will undergo verification by the NAIS platform ([picante](https://github.com/nais/picante)) and will be uploaded to an SBOM analysis platform known as [Dependency-Track](https://dependencytrack.org/). In Dependency-Track, you can examine the attestation as well as the vulnerabilities present in your image and its dependencies.

> GHCR serves as a OCI registry hosted by GitHub, but it has certain limitations, such as imposing strict rate limits on the number of requests. We've encountered challenges with these rate limits, particularly when upgrading a cluster or restoring from a backup. In such instances, we've had to patiently wait for the rate limits to reset before deploying / restoring our applications.
>
> On the other hand, GAR is a OCI registry hosted by Google, and we find it to be a more favorable solution for our needs. Additionally, as we transition to the cloud, the seamless integration with the Google Cloud Platform further enhances its appeal as a beneficial option for our operations.

## Trello ticket number and link

- [TC-380](https://trello.com/c/9wLGC3Tp/380-bytte-fra-snyk-til-github-advanced-security)
