### PR TITLE
Republisering info

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
@@ -58,7 +58,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # ratchet:github/codeql-action/init@v4.35.5
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # ratchet:github/codeql-action/init@v4.36.1
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -74,7 +74,7 @@ jobs:
         # queries: security-extended,security-and-quality
 
 
-        uses: github/codeql-action/autobuild@9e0d7b8d25671d64c341c19c0152d693099fb5ba # ratchet:github/codeql-action/autobuild@v4.35.5
+        uses: github/codeql-action/autobuild@87557b9c84dde89fdd9b10e88954ac2f4248e463 # ratchet:github/codeql-action/autobuild@v4.36.1
       # ℹ️ Command-line programs to run using the OS shell.
 
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -89,6 +89,6 @@ jobs:
       #     ./location_of_script_within_repo/buildscript.sh
       - name: Perform CodeQL Analysis
 
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # ratchet:github/codeql-action/analyze@v4.35.5
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # ratchet:github/codeql-action/analyze@v4.36.1
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
@@ -71,7 +71,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
 
       - name: Deploy application
         uses: nais/deploy/actions/deploy@1b32d71ce5c97174c039ac739b10220dab5a001f # ratchet:nais/deploy/actions/deploy@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
 
       - name: Deploy application
         uses: nais/deploy/actions/deploy@1b32d71ce5c97174c039ac739b10220dab5a001f # ratchet:nais/deploy/actions/deploy@v2
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
 
       - name: Deploy application
         uses: nais/deploy/actions/deploy@1b32d71ce5c97174c039ac739b10220dab5a001f # ratchet:nais/deploy/actions/deploy@v2

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     implementation(libs.org.springframework.cloud.spring.cloud.starter.gateway)
     implementation(libs.no.nav.poao.tilgang.client)
     implementation(libs.org.jetbrains.kotlin.kotlin.reflect)
-    implementation(libs.com.fasterxml.jackson.module.jackson.module.kotlin)
     implementation(libs.org.jetbrains.kotlin.kotlin.stdlib.jdk8)
     implementation(libs.com.github.ben.manes.caffeine.caffeine)
     implementation(libs.io.micrometer.micrometer.registry.prometheus)
@@ -58,8 +57,8 @@ dependencies {
 
     testImplementation(libs.org.springframework.boot.spring.boot.starter.security.oauth2.client)
     testImplementation(libs.org.springframework.boot.spring.boot.starter.security)
-    testImplementation("org.springframework.boot:spring-boot-starter-webflux-test:4.0.4")
-    testImplementation("org.springframework.boot:spring-boot-starter-security-test:4.0.4")
+    testImplementation("org.springframework.boot:spring-boot-starter-webflux-test:4.0.6")
+    testImplementation("org.springframework.boot:spring-boot-starter-security-test:4.0.6")
     testImplementation(libs.no.nav.security.mock.oauth2.server)
     testImplementation(libs.org.mockito.kotlin.mockito.kotlin)
     testImplementation(libs.org.springframework.boot.spring.boot.starter.test)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,25 +2,22 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-com-fasterxml-jackson-module-jackson-module-kotlin = "2.18.7"
 com-github-ben-manes-caffeine-caffeine = "3.2.4"
 com-squareup-okhttp3 = "5.2.3"
 io-micrometer-micrometer-registry-prometheus = "1.14.14"
 # Temporary security override for CVE-2026-42584 / CVE-2026-42581 / CVE-2026-42579.
 # Remove when Spring Boot/Spring Cloud BOM manages Netty at >= 4.2.14.Final.
 io-netty-netty-bom = "4.2.14.Final"
-no-nav-common = "4.2026.05.19_05.29-4b5633c82ec0"
-no-nav-poao-tilgang-client = "2026.05.05_13.02-76cbce4f654a"
+no-nav-common = "4.2026.06.09_07.11-eccd6d131c44"
+no-nav-poao-tilgang-client = "4.2026.06.03_06.17-9fbee8d2bb00"
 no-nav-security-mock-oauth2-server = "3.0.3"
 org-jetbrains-kotlin = "2.3.21"
 org-mockito-kotlin-mockito-kotlin = "5.4.0"
 org-springframework-boot = "4.0.6"
 org-springframework-cloud-spring-cloud-starter-gateway = "5.0.1"
-org-springframework-security-spring-security-test = "7.0.0"
 org-junit-platform-junit-platform-launcher = "6.0.3"
 
 [libraries]
-com-fasterxml-jackson-module-jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "com-fasterxml-jackson-module-jackson-module-kotlin" }
 com-github-ben-manes-caffeine-caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "com-github-ben-manes-caffeine-caffeine" }
 com-squareup-okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "com-squareup-okhttp3" }
 com-squareup-okhttp3-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "com-squareup-okhttp3" }
@@ -48,4 +45,3 @@ org-springframework-boot-spring-boot-starter-security = { module = "org.springfr
 org-springframework-boot-spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "org-springframework-boot" }
 org-springframework-boot-spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux", version.ref = "org-springframework-boot" }
 org-springframework-cloud-spring-cloud-starter-gateway = { module = "org.springframework.cloud:spring-cloud-starter-gateway-server-webflux", version.ref = "org-springframework-cloud-spring-cloud-starter-gateway" }
-org-springframework-security-spring-security-test = { module = "org.springframework.security:spring-security-test", version.ref = "org-springframework-security-spring-security-test" }

--- a/web-app/src/view/republisering-kafka/republisering-kafka.tsx
+++ b/web-app/src/view/republisering-kafka/republisering-kafka.tsx
@@ -66,7 +66,7 @@ export function RepubliseringKafka() {
 			/>
 			<RepubliseringsKort
 				tittel="Republiser arbeidsoppfølgingskontor endret"
-				beskrivelse="Republiserer kontoret til alle brukere med aktiv oppfølgingsperiode på topic dab.arbeidsoppfolgingskontortilordninger-v2"
+				beskrivelse="Republiserer kontoret til alle brukere med aktiv oppfølgingsperiode på topic dab.arbeidsoppfolgingskontortilordninger-v2. Husk å stoppe lytterne i ao-kontor med unleash-toggle ao-kontor.stopp-kafkalyttere først."
 				request={republiserArbeidsoppfolgingskontorendret}
 				topicNavn={'dab.arbeidsoppfolgingskontortilordninger-v2'}
 			/>


### PR DESCRIPTION
La inn beskjed om at man bør stoppe kafkalyttere for ao-kontor før man starter republisering av kontorer. Dette er lurt fordi republiseringsjobben i ao-kontor pt leser ut alle kontortilhørighetene og publiserer dem basert på slik dataene så ut da de ble lest. Hvis man ikke stopper lytterne kan dataene bli endret i mellomtiden slik at man republiserer gamle data. 

Oppdaterte også noen avhengigheter og fjernet noen dependencies som ikke lenger brukes. 

https://trello.com/c/2TxjQb2d/1651-advarsel-i-poao-admin-om-republisering-av-kontor